### PR TITLE
Hotfix/devel package

### DIFF
--- a/pirum
+++ b/pirum
@@ -977,7 +977,7 @@ EOF;
  */
 class Pirum_Package
 {
-    const PACKAGE_FILE_PATTERN = '#^(?P<release>(?P<name>.+)\-(?P<version>[\d\.]+((?:RC|beta|alpha)\d*)?))\.tgz$#i';
+    const PACKAGE_FILE_PATTERN = '#^(?P<release>(?P<name>.+)\-(?P<version>[\d\.]+((?:RC|beta|alpha|dev)\d*)?))\.tgz$#i';
 
     protected $package;
     protected $tmpDir;


### PR DESCRIPTION
I added "|dev" to the package regex, as development packages are perfectly valid, and this is the appropriate format for the package name (e.g., Loader-2.0.0dev3).
