### PR TITLE
Allow version numbers like 0.0.1a or 0.0.2b1

### DIFF
--- a/pirum
+++ b/pirum
@@ -1046,7 +1046,7 @@ EOF;
  */
 class Pirum_Package
 {
-    const PACKAGE_FILE_PATTERN = '#^(?P<release>(?P<name>.+)\-(?P<version>[\d\.]+((?:RC|beta|alpha|dev|snapshot)\d*)?))\.tgz$#i';
+    const PACKAGE_FILE_PATTERN = '#^(?P<release>(?P<name>.+)\-(?P<version>[\d\.]+((?:RC|beta|alpha|dev|snapshot|a|b)\d*)?))\.tgz$#i';
 
     protected $package;
     protected $tmpDir;


### PR DESCRIPTION
Some pear packages in the wild (ext/memcached e.g.) will use the above package naming and `pear package` will happily create a filename like foo-0.0.2b1 which Pirum then will refuse to process.

The patch updates the package name validation regex to allow the characters "a" and "b" next to the "alpha", "beta" etc. labels.
