### PR TITLE
PEAR Optional Dependency Groups

### DIFF
--- a/pirum
+++ b/pirum
@@ -478,11 +478,25 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                             $deps = array($deps);
                         }
                     }
+
+                    $grps = array();
+                    if (isset($package['deps']['group'])) {
+                        $grps = $package['deps']['group'];
+                    }
                 ?>
                     <h3><?php echo $package['name'] ?><small> - <?php echo $package['summary'] ?></small></h3>
                     <p><?php echo $package['description'] ?></p>
                     <table>
                         <tr><th>Install command</th><td><strong><?php echo $package['extension'] != null ? 'pecl' : 'pear' ?> install <?php echo $this->server->alias ?>/<?php echo $package['name'] ?></strong></td></tr>
+                        <?php if ($grps): ?><?php
+                            $groups = array();
+                            foreach ($grps as $grp) {
+                                $groups[] = ($package['extension'] != null ? 'pecl' : 'pear').' install '.$this->server->alias.'/'.$package['name'].'#'.$grp['attribs']['name'].'&nbsp;<small>('.$grp['attribs']['hint'].')</small>';
+                            }
+                            $groups = implode('<br/>', $groups);
+                        ?>
+                        <tr><th>Install groups:</th><td><?php echo $groups ?></td></tr>
+                        <?php endif; ?>
                         <tr><th>License</th><td><?php echo $package['license'] ?></td></tr>
                         <?php if ($deps): ?>
                             <tr><th>Dependencies</th><td>

--- a/pirum
+++ b/pirum
@@ -1203,7 +1203,12 @@ class Pirum_Package
 
     public function getDeps()
     {
-        return serialize($this->XMLToArray($this->package->dependencies));
+        $deps = $this->XMLToArray($this->package->dependencies);
+        if ($this->package->dependencies->group->count() > 0) {
+            $deps['group'] = $this->XMLGroupDepsToArray($this->package->dependencies->group);
+        } // if
+
+        return serialize($deps);
     }
 
     public function getMinPhp()
@@ -1322,6 +1327,32 @@ class Pirum_Package
         }
 
         return $array;
+    }
+
+    protected function XMLGroupDepsToArray($xml)
+    {
+        if ($xml->count() == 0) return array();
+
+        $deps = array();
+        foreach ($xml as $group) {
+            // Extract group attribs (shared by all children)
+            $attribs = array();
+            foreach ($group->attributes() as $key => $val) {
+                $attribs[$key] = (string) $val;
+            } // foreach
+
+            // Create one group dependency per childern
+            foreach ($group->children() as $type => $value) {
+                $value = $this->XMLToArray($value);
+
+                $deps[] = array(
+                    'attribs' => $attribs,
+                    $type     => $value,
+                );
+            }
+        }
+
+        return $deps;
     }
 }
 


### PR DESCRIPTION
Pirum does not support PEAR Optional Dependency Groups. When you try to install this kind of packages from a Pirum served channel, the PEAR installer fails to detect the group and aborts with an error. The patch generates the correct structure so the channels served by Pirum can hold dependency groups without problems.

PEAR allows an "optional dependency groups" that define blocks of optional packages. Each group provides some feature (usually "plugins" or drivers) and must be installed in a block.

This dependencies are almost indentical to normal dependencies but enclosed with <group> tags that defines the group name and provides a description ('hint'):

``` xml
<group name="remoteshell" hint="Add support for Remote Shell Operations">
    <package>
        <name>SSH_RemoteShell</name>
        <channel>pear.php.net</channel>
    </package>
    <extension>
        <name>ssh2</name>
    </extension>
</group>      
```

PEAR needs a "special format" in package deps.[version].txt file to hold this dependencies: The dependency array to be serialized must looks like (reverse engineering from http://pear.php.net/rest/r/mdb2/deps.2.5.0b3.txt, seems to be undocumented):

``` PHP
<?php
array(
    'required' => array(...),
    'group' => array(
        array(
            'attribs' => array('hint' => '...', 'name' => 'grp1'),
            'package' => array('name' => 'dep1', 'channel' => '...', ...),
        ),
        array(
            'attribs' => array('hint' => '...', 'name' => 'grp1'),
            'package' => array('name' => 'dep2', 'channel' => '...', ...),
        ),
        array(
            'attribs' => array('hint' => '...', 'name' => 'grp2'),
            'package' => array('name' => 'dep3', 'channel' => '...', ...),
        ),
    ),
)
```

Each entry is a package, subpackage or extension that belongs to one group. The attribs key indicates the group the package belongs to and the dependency is defined as usual. If one package belongs to several groups or the group has more than one package, must to be duplicated.

The patch generates this array so the channels served by pirum holds dependency groups without problems.
