### PR TITLE
Preventing raw PHP warnings on composer channel generation with invalid channels

### DIFF
--- a/pirum
+++ b/pirum
@@ -629,7 +629,11 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                                         if (false === strpos($dataKey, '/')) {
                                             $channelUrl = 'http://'.$value['channel'];
                                             if (!isset($pearChannels[$channelUrl])) {
-                                                $channelInfo = new \SimpleXMLElement($channelUrl.'/channel.xml', null, true);
+                                                try {
+                                                    $channelInfo = @new \SimpleXMLElement($channelUrl.'/channel.xml', null, true);
+                                                } catch (Exception $e) {
+                                                    throw new Exception(sprintf('Channel "%s" could not be reached for package %s.', $channelUrl, $packageDef['name']));
+                                                }
                                                 $pearChannels[$channelUrl] = ((string) $channelInfo->suggestedalias[0]) ?: (string) $channelInfo->name[0];
                                             }
                                             $dataKey = $pearChannels[$channelUrl].'/'.$dataKey;

--- a/pirum
+++ b/pirum
@@ -632,7 +632,7 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                                                 try {
                                                     $channelInfo = @new \SimpleXMLElement($channelUrl.'/channel.xml', null, true);
                                                 } catch (Exception $e) {
-                                                    throw new Exception(sprintf('Channel "%s" could not be reached for package %s.', $channelUrl, $packageDef['name']));
+                                                    throw new Exception(sprintf('Channel "%s" could not be reached for package %s version %s.', $channelUrl, $packageDef['name'], $version['version']));
                                                 }
                                                 $pearChannels[$channelUrl] = ((string) $channelInfo->suggestedalias[0]) ?: (string) $channelInfo->name[0];
                                             }


### PR DESCRIPTION
Hi!

Since I've updated to 1.1.2 `pirum build` stopped working on my automated build scripts. It was working fine in 1.1.1. I've double checked my current packages and everything is fine with them. The command was giving me this:

```
   INFO   Building composer repository.
PHP Warning:  SimpleXMLElement::__construct(): php_network_getaddresses: getaddrinfo failed: Name or service not known in /usr/bin/pirum on line 636
PHP Stack trace:
PHP   1. {main}() /usr/bin/pirum:0
PHP   2. Pirum_CLI->run() /usr/bin/pirum:22
PHP   3. Pirum_CLI->runAdd() /usr/bin/pirum:81
PHP   4. Pirum_CLI->runBuild() /usr/bin/pirum:179
PHP   5. Pirum_Builder->build() /usr/bin/pirum:185
PHP   6. Pirum_Builder->buildComposerRepository() /usr/bin/pirum:269
PHP   7. SimpleXMLElement->__construct() /usr/bin/pirum:636
PHP Warning:  SimpleXMLElement::__construct(http://http://pear.phpunit.de/channel.xml): failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known in /usr/bin/pirum on line 636
PHP Stack trace:
PHP   1. {main}() /usr/bin/pirum:0
PHP   2. Pirum_CLI->run() /usr/bin/pirum:22
PHP   3. Pirum_CLI->runAdd() /usr/bin/pirum:81
PHP   4. Pirum_CLI->runBuild() /usr/bin/pirum:179
PHP   5. Pirum_Builder->build() /usr/bin/pirum:185
PHP   6. Pirum_Builder->buildComposerRepository() /usr/bin/pirum:269
PHP   7. SimpleXMLElement->__construct() /usr/bin/pirum:636
PHP Warning:  SimpleXMLElement::__construct(): I/O warning : failed to load external entity "http://http://pear.phpunit.de/channel.xml" in /usr/bin/pirum on line 636
PHP Stack trace:
PHP   1. {main}() /usr/bin/pirum:0
PHP   2. Pirum_CLI->run() /usr/bin/pirum:22
PHP   3. Pirum_CLI->runAdd() /usr/bin/pirum:81
PHP   4. Pirum_CLI->runBuild() /usr/bin/pirum:179
PHP   5. Pirum_Builder->build() /usr/bin/pirum:185
PHP   6. Pirum_Builder->buildComposerRepository() /usr/bin/pirum:269
PHP   7. SimpleXMLElement->__construct() /usr/bin/pirum:636
   ERROR  String could not be parsed as XML (Exception, 0)
```

After some debugging sessions I've discovered old packages with invalid and unavailable channels declared as dependencies. I've patched pirum to not throw warnings when this happens. This PR changes suppresses the warning above and returns this error:

```   ERROR  Channel "http://http://pear.phpunit.de" could not be reached for package pear-Respect/Doc version 0.1.0. (Exception, 0)

```

This helped me to track every invalid package so I could fix them, It may help others as well.

I couldn't find any other solution than an `@new SimpleXmlElement` to suppress the warning. I'll keep researching, but these network errors from PHP streams are hard to catch.

Let me know if there's anything I could improve on this.

Thanks!
```
