### PR TITLE
Small fix to XMLtoArray method when converting multiple elements of the same name to a nested array.

### DIFF
--- a/pirum
+++ b/pirum
@@ -1523,7 +1523,7 @@ class Pirum_Package
             $value = count($value->children()) ? $this->XMLToArray($value) : (string) $value;
 
             if (array_key_exists($key, $array)) {
-                if (!isset($array[$key][0])) {
+                if (!is_array($array[$key])) {
                     $array[$key] = array($array[$key]);
                 }
                 $array[$key][] = $value;


### PR DESCRIPTION
Changes isset($value[0]) to is_array($value). isset($value[0]) is true for strings causing a fatal error in the subsequent statement.
