### PR TITLE
Don't display conflicts as deps

### DIFF
--- a/pirum
+++ b/pirum
@@ -485,8 +485,13 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                     $deps = array();
                     if (isset($package['deps']['required']['package'])) {
                         $deps = $package['deps']['required']['package'];
-                        if (isset($deps['name'])) {
+                        if (isset($deps['name']) && !isset($deps['conflicts'])) {
                             $deps = array($deps);
+                        }
+                        foreach ($deps as $i => $dep) {
+                            if (isset($dep['conflicts'])) {
+                                unset($deps[$i]);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Pirum will now honor `conflicts` designation in a package dependency when building the index page, and not display a conflicting package _as_ a dependency.

See [package.xml 2.0 docs](https://pear.php.net/manual/en/guide.developers.package2.dependencies.php) for details on dependency conflicts.
