### PR TITLE
Compatibility patch for PHP 5.2.x

### DIFF
--- a/pirum
+++ b/pirum
@@ -676,7 +676,11 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
             }
         }
 
-        file_put_contents($this->buildDir.'/packages.json', json_encode($repository, JSON_PRETTY_PRINT));
+        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+            file_put_contents($this->buildDir.'/packages.json',json_encode($repository, JSON_PRETTY_PRINT));
+        } else {
+            file_put_contents($this->buildDir.'/packages.json',json_encode($repository));
+        }
     }
 
     protected function createComposerConstraint(array $data)


### PR DESCRIPTION
Removed second parameter of json_encode call for PHP versions prior to 5.3.

This parameter is not available for these versions, resulting in a warning and an empty file packages.json. 

http://de.php.net/json_encode
