### PR TITLE
Reduce line breaks.

### DIFF
--- a/pirum
+++ b/pirum
@@ -766,6 +766,8 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
         $snapshot = '';
         $allreleases = '';
         $allreleases2 = '';
+        $first = true;
+        $this->formatter and print $this->formatter->formatSection('INFO', 'Building release', false);
         foreach ($package['releases'] as $release) {
             if ('stable' == $release['stability'] && !$stable) {
                 $stable = $release['version'];
@@ -794,8 +796,10 @@ EOF;
 
 EOF;
 
-            $this->buildRelease($dir, $package, $release);
+            $this->buildRelease($dir, $package, $release, $first);
+            $first = false;
         }
+        $this->formatter and print "\n";
 
         if (count($package['releases'])) {
             file_put_contents($dir.'/latest.txt', $package['releases'][0]['version']);
@@ -838,9 +842,10 @@ EOF
         );
     }
 
-    protected function buildRelease($dir, $package, $release)
+    protected function buildRelease($dir, $package, $release, $first)
     {
-        $this->formatter and print $this->formatter->formatSection('INFO', "Building release {$release['version']} for {$package['name']}.");
+        !$first and $this->formatter and print $this->formatter->format(',');
+        $this->formatter and print $this->formatter->format(' ' . $release['version']);
 
         $url = strtolower($package['name']);
 
@@ -1204,8 +1209,11 @@ EOF;
             $packages[$file] = $package;
         }
 
+        $first = true;
+        $this->formatter and print $this->formatter->formatSection('INFO', 'Parsing package', false);
         foreach ($packages as $file => $package) {
-            $this->formatter and print $this->formatter->formatSection('INFO', sprintf('Parsing package %s for %s.', $package->getVersion(), $package->getName()));
+            !$first and $this->formatter and print $this->formatter->format(',');
+            $this->formatter and print $this->formatter->format(' ' . $package->getName() . ' ' . $package->getVersion());
 
             if ($package->getChannel() != $this->server->name) {
                 throw new Exception(sprintf('Package "%s" channel (%s) is not %s.', $package->getName(), $package->getChannel(), $this->server->name));
@@ -1239,7 +1247,10 @@ EOF;
             );
 
             $this->packages[$package->getName()]['maintainers'] = array_merge($package->getMaintainers(), $this->packages[$package->getName()]['maintainers']);
+
+            $first = false;
         }
+        $this->formatter and print "\n";
 
         ksort($this->packages);
     }
@@ -1635,13 +1646,14 @@ class Pirum_CLI_Formatter
      *
      * @param string  $section  The section name
      * @param string  $text     The text message
+     * @param boolean $newline  End with line break?
      */
-    public function formatSection($section, $text)
+    public function formatSection($section, $text, $newline = true)
     {
         $section = $style = array_key_exists($section, $this->styles) ? $section : 'INFO';
         $section = " $section ".str_repeat(' ', max(0, 5 - strlen($section)));
         $style .= '_SECTION';
 
-        return sprintf("  %s %s\n", $this->format($section, $style), $text);
+        return sprintf('  %s %s%s', $this->format($section, $style), $text, $newline ? "\n" : '');
     }
 }


### PR DESCRIPTION
If there are a lot of releases (and/or a lof of packages), the output could become really long. I'm talking about adding a Horde release overrunning my 1000 lines console buffer.
This patch condenses all parsed releases, and all built releases of a single package into a single line. At some point the formatter could be extended to automatically wrap and indent continuation lines, but for now this works well.
