### PR TITLE
issue with dependency groups

### DIFF
--- a/pirum
+++ b/pirum
@@ -1430,8 +1430,19 @@ class Pirum_Package
     public function getDeps()
     {
         $deps = $this->XMLToArray($this->package->dependencies);
-        if (isset($this->package->dependencies->group) && $this->package->dependencies->group->length > 0) {
-            $deps['group'] = $this->XMLGroupDepsToArray($this->package->dependencies->group);
+        if (isset($this->package->dependencies->group))
+        {
+            $group = $this->package->dependencies->group;
+            if (is_callable(array($group, "count"))) {
+                //php 5.3+;
+                if ($group->count() > 0)
+                    $deps['group'] = $this->XMLGroupDepsToArray($group);
+            }
+            else {
+                //php 5.2 simplexml didn't have count()
+                if ($group->length > 0)
+                    $deps['group'] = $this->XMLGroupDepsToArray($group);
+            }
         }
 
         return serialize($deps);


### PR DESCRIPTION
Running the master version of pirum on php 5.4.10, I'm having issues publishing packages with dependency groups. The issue seems to be related to the simplexml api. This patch partially fixed the issue for me, in that the packages are now installable, but for some reason each install group appears twice in the generated html page.
