### PR TITLE
Skip invalid pear channels when building the composer index

### DIFF
--- a/pirum
+++ b/pirum
@@ -630,6 +630,8 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
 
         $vendor = !empty($this->server->alias) ? $this->server->alias : $this->server->name;
 
+        $invalidPearChannels = array();
+
         foreach ($this->packages as $package) {
             // standard package fields
             $packageDef = array('versions' => array());
@@ -703,10 +705,17 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                                         if (false === strpos($dataKey, '/')) {
                                             $channelUrl = 'http://'.$value['channel'];
                                             if (!isset($pearChannels[$channelUrl])) {
+                                                if (in_array($channelUrl, $invalidPearChannels)) {
+                                                    print $this->formatter->formatSection('WARN', sprintf('Invalid channel "%s"', $channelUrl));
+                                                    continue;
+                                                }
+
                                                 try {
                                                     $channelInfo = @new SimpleXMLElement($channelUrl.'/channel.xml', null, true);
                                                 } catch (Exception $e) {
-                                                    throw new Exception(sprintf('Channel "%s" could not be reached for package %s version %s.', $channelUrl, $package['name'], $version['version']));
+                                                    print $this->formatter->formatSection('WARN', sprintf('Channel "%s" could not be reached for package %s version %s.', $channelUrl, $package['name'], $version['version']));
+                                                    $invalidPearChannels[] = $channelUrl;
+                                                    continue;
                                                 }
                                                 if ($tmp = (string) $channelInfo->suggestedalias[0]) {
                                                     $pearChannels[$channelUrl] = $tmp;

--- a/pirum
+++ b/pirum
@@ -706,14 +706,14 @@ pear install <?php echo $this->server->alias ?>/package_name-beta</code></pre>
                                             $channelUrl = 'http://'.$value['channel'];
                                             if (!isset($pearChannels[$channelUrl])) {
                                                 if (in_array($channelUrl, $invalidPearChannels)) {
-                                                    print $this->formatter->formatSection('WARN', sprintf('Invalid channel "%s"', $channelUrl));
+                                                    print $this->formatter->formatSection('ERROR', sprintf('Invalid channel "%s"', $channelUrl));
                                                     continue;
                                                 }
 
                                                 try {
                                                     $channelInfo = @new SimpleXMLElement($channelUrl.'/channel.xml', null, true);
                                                 } catch (Exception $e) {
-                                                    print $this->formatter->formatSection('WARN', sprintf('Channel "%s" could not be reached for package %s version %s.', $channelUrl, $package['name'], $version['version']));
+                                                    print $this->formatter->formatSection('ERROR', sprintf('Channel "%s" could not be reached for package %s version %s.', $channelUrl, $package['name'], $version['version']));
                                                     $invalidPearChannels[] = $channelUrl;
                                                     continue;
                                                 }


### PR DESCRIPTION
For older packages, there are cases where dependencies no longer exist on a channel. This is especially true for phpunit, whose pear channel no longer exists.

Rather than break the entire build, we WARN that this is happening and allow pear channel maintainers to make a judgement call as to whether the composer repo is important (in this case, likely not).